### PR TITLE
Updated Cake.Core package reference to 0.26.1

### DIFF
--- a/nuspec/nuget/Cake.ProtobufTools.nuspec
+++ b/nuspec/nuget/Cake.ProtobufTools.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/cake-contrib/Cake.ProtobufTools</projectUrl>
     <iconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</iconUrl>
     <description>ProtobufTools Addin for runing Google's Protobuf protoc tool.</description>
-    <copyright>Copyright 2017 (c) Miha Markic and contributors</copyright>
+    <copyright>Copyright 2018 (c) Miha Markic and contributors</copyright>
     <tags>Cake Script CodeGenerator ProtobufTools</tags>
     <repository type="GitHub" url="https://github.com/cake-contrib/Cake.ProtobufTools" />
   </metadata>

--- a/nuspec/nuget/Cake.ProtobufTools.nuspec
+++ b/nuspec/nuget/Cake.ProtobufTools.nuspec
@@ -17,7 +17,7 @@
   <files>
     <file src="net46\Cake.ProtobufTools.dll" target="lib/net46" />
     <file src="net46\Cake.ProtobufTools.xml" target="lib/net46" />
-    <file src="netstandard1.6\Cake.ProtobufTools.dll" target="lib/netstandard1.6" />
-    <file src="netstandard1.6\Cake.ProtobufTools.xml" target="lib/netstandard1.6" />
+    <file src="netstandard2.0\Cake.ProtobufTools.dll" target="lib/netstandard2.0" />
+    <file src="netstandard2.0\Cake.ProtobufTools.xml" target="lib/netstandard2.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.ProtobufTools.nuspec
+++ b/nuspec/nuget/Cake.ProtobufTools.nuspec
@@ -14,9 +14,7 @@
     <tags>Cake Script CodeGenerator ProtobufTools</tags>
     <repository type="GitHub" url="https://github.com/cake-contrib/Cake.ProtobufTools" />
   </metadata>
-  <files>
-    <file src="net46\Cake.ProtobufTools.dll" target="lib/net46" />
-    <file src="net46\Cake.ProtobufTools.xml" target="lib/net46" />
+  <files>    
     <file src="netstandard2.0\Cake.ProtobufTools.dll" target="lib/netstandard2.0" />
     <file src="netstandard2.0\Cake.ProtobufTools.xml" target="lib/netstandard2.0" />
   </files>

--- a/src/Cake.ProtobufTools.Tests/Cake.ProtobufTools.Tests.csproj
+++ b/src/Cake.ProtobufTools.Tests/Cake.ProtobufTools.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake" Version="0.22.0" />
-    <PackageReference Include="Cake.Testing" Version="0.22.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Cake" Version="0.26.1" />
+    <PackageReference Include="Cake.Testing" Version="0.26.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.ProtobufTools/Cake.ProtobufTools.csproj
+++ b/src/Cake.ProtobufTools/Cake.ProtobufTools.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DocumentationFile></DocumentationFile>

--- a/src/Cake.ProtobufTools/Cake.ProtobufTools.csproj
+++ b/src/Cake.ProtobufTools/Cake.ProtobufTools.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/src/Cake.ProtobufTools/Cake.ProtobufTools.csproj
+++ b/src/Cake.ProtobufTools/Cake.ProtobufTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
     <DocumentationFile></DocumentationFile>
@@ -14,6 +14,6 @@
     <DocumentationFile>bin\Release\net46\Cake.ProtobufTools.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Without this change it is not working with latest cake binaries. 
Exception: 

The assembly 'Cake.ProtobufTools, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
is referencing an older version of Cake.Core (0.22.0).
This assembly need to reference at least Cake.Core version 0.26.0.
Another option is to downgrade Cake to an earlier version.
It's not recommended, but you can explicitly opt-out of assembly verification
by configuring the Skip Verification setting to true
(i.e. command line parameter "--settings_skipverification=true",
environment variable "CAKE_SETTINGS_SKIPVERIFICATION=true",
read more about configuration at https://cakebuild.net/docs/fundamentals/configuration)