### PR TITLE
Allow subclassing of ProtocSettings

### DIFF
--- a/src/Cake.ProtobufTools/ArgumentsBuilderExtension.cs
+++ b/src/Cake.ProtobufTools/ArgumentsBuilderExtension.cs
@@ -54,7 +54,7 @@ namespace Cake.ProtobufTools
         public static void AppendArguments<TSettings>(ProcessArgumentBuilder builder, TSettings settings, bool preCommand)
             where TSettings : AutoToolSettings, new()
         {
-            foreach (var property in typeof(TSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            foreach (var property in settings.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
                 foreach (string argument in GetArgumentFromProperty(property, settings, preCommand: preCommand))
                 {


### PR DESCRIPTION
Looking at the code, it seems like the ArgumentBuilder is supposed to support subclassing ProtocSettings to generate custom parameters for protoc.exe. The thing is that the generic extension method is always called with the ProtocSettings type, so it will never add the custom properties.

By switching from typeof(T) to settings.GetType() we can enable such a feature.

I have already successfully tested this with the Grpc package to generate grpc service stubs.